### PR TITLE
Fix `Sully's Mod` compatibility

### DIFF
--- a/src/main/resources/data/crabbersdelight/recipe/lanternfish_barrel.json
+++ b/src/main/resources/data/crabbersdelight/recipe/lanternfish_barrel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "sullysmod"
+    }
+  ],
   "type": "minecraft:crafting_shaped",
   "category": "building",
   "key": {
@@ -12,7 +18,7 @@
     "###"
   ],
   "result": {
-    "item": "crabbersdelight:lanternfish_barrel"
+    "id": "crabbersdelight:lanternfish_barrel"
   },
   "show_notification": true
 }

--- a/src/main/resources/data/crabbersdelight/recipe/lanternfish_from_barrel.json
+++ b/src/main/resources/data/crabbersdelight/recipe/lanternfish_from_barrel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "sullysmod"
+    }
+  ],
   "type": "minecraft:crafting_shapeless",
   "category": "misc",
   "ingredients": [
@@ -8,6 +14,6 @@
   ],
   "result": {
     "count": 9,
-    "item": "sullysmod:lanternfish"
+    "id": "sullysmod:lanternfish"
   }
 }


### PR DESCRIPTION
Added `neoforge:conditions` to check if `sullysmod` mod ID is loaded.

I don't have this mod installed and don't want to see errors related to it in logs.

Fixes https://github.com/AlabasterLeking/Crabbers-Delight/issues/35.