### PR TITLE
Fix loot modifiers for 1.21

### DIFF
--- a/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_cooked_frog_leg_from_frog.json
+++ b/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_cooked_frog_leg_from_frog.json
@@ -3,11 +3,11 @@
   "conditions": [
     {
       "condition": "minecraft:entity_properties",
-      "entity": "killer",
+      "entity": "attacker",
       "predicate": {
         "equipment": {
           "mainhand": {
-            "tag": "farmersdelight:tools/knives"
+            "items": "#farmersdelight:tools/knives"
           }
         }
       }

--- a/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_cooked_tentacles_from_glow_squid.json
+++ b/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_cooked_tentacles_from_glow_squid.json
@@ -3,11 +3,11 @@
   "conditions": [
     {
       "condition": "minecraft:entity_properties",
-      "entity": "killer",
+      "entity": "attacker",
       "predicate": {
         "equipment": {
           "mainhand": {
-            "tag": "farmersdelight:tools/knives"
+            "items": "#farmersdelight:tools/knives"
           }
         }
       }

--- a/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_cooked_tentacles_from_squid.json
+++ b/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_cooked_tentacles_from_squid.json
@@ -3,11 +3,11 @@
   "conditions": [
     {
       "condition": "minecraft:entity_properties",
-      "entity": "killer",
+      "entity": "attacker",
       "predicate": {
         "equipment": {
           "mainhand": {
-            "tag": "farmersdelight:tools/knives"
+            "items": "#farmersdelight:tools/knives"
           }
         }
       }

--- a/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_raw_frog_leg_from_frog.json
+++ b/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_raw_frog_leg_from_frog.json
@@ -3,11 +3,11 @@
   "conditions": [
     {
       "condition": "minecraft:entity_properties",
-      "entity": "killer",
+      "entity": "attacker",
       "predicate": {
         "equipment": {
           "mainhand": {
-            "tag": "farmersdelight:tools/knives"
+            "items": "#farmersdelight:tools/knives"
           }
         }
       }

--- a/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_tentacles_from_glow_squid.json
+++ b/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_tentacles_from_glow_squid.json
@@ -3,11 +3,11 @@
   "conditions": [
     {
       "condition": "minecraft:entity_properties",
-      "entity": "killer",
+      "entity": "attacker",
       "predicate": {
         "equipment": {
           "mainhand": {
-            "tag": "farmersdelight:tools/knives"
+            "items": "#farmersdelight:tools/knives"
           }
         }
       }

--- a/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_tentacles_from_squid.json
+++ b/src/main/resources/data/crabbersdelight/loot_modifiers/scavenging_tentacles_from_squid.json
@@ -3,11 +3,11 @@
   "conditions": [
     {
       "condition": "minecraft:entity_properties",
-      "entity": "killer",
+      "entity": "attacker",
       "predicate": {
         "equipment": {
           "mainhand": {
-            "tag": "farmersdelight:tools/knives"
+            "items": "#farmersdelight:tools/knives"
           }
         }
       }


### PR DESCRIPTION
Updated loot modifiers format to match `Farmer's Delight`'s 1.21 one:
- `"entity": "killer"` —> `"entity": "attacker"`
- `"tag": "farmersdelight:tools/knives"` —> `"items": "#farmersdelight:tools/knives"`

I used this file as an example: [data/farmersdelight/loot_modifiers/scavenging_ham_from_pig.json](https://github.com/vectorwing/FarmersDelight/blob/1.21/src/main/resources/data/farmersdelight/loot_modifiers/scavenging_ham_from_pig.json).

Fixes https://github.com/AlabasterLeking/Crabbers-Delight/issues/36.