### PR TITLE
Update crab entity loot table

### DIFF
--- a/src/main/resources/data/crabbersdelight/loot_table/entities/crab.json
+++ b/src/main/resources/data/crabbersdelight/loot_table/entities/crab.json
@@ -13,9 +13,10 @@
           "name": "crabbersdelight:crab_claw",
           "conditions": [
             {
-              "condition": "minecraft:random_chance_with_looting",
-              "chance": 0.2,
-              "looting_multiplier": 2
+              "condition": "minecraft:random_chance_with_enchanted_bonus",
+              "unenchanted_chance": 0.2,
+              "enchantment": "minecraft:looting",
+              "enchanted_chance": 0.4
             }
           ]
         }


### PR DESCRIPTION
- Updated conditions to 1.21 format.

Even though the crab entity isn't added back yet, Minecraft throws error trying to parse its loot table:
```log
[net.minecraft.world.level.storage.loot.LootDataType/]: Couldn't parse element ResourceKey[minecraft:root / minecraft:loot_table]:crabbersdelight:entities/crab - Failed to parse either. First: Unknown registry key in ResourceKey[minecraft:root / minecraft:loot_condition_type]: minecraft:random_chance_with_looting; Second: Not a json array: {"condition":"minecraft:random_chance_with_looting","chance":0.2,"looting_multiplier":2}
```

This change fixed the error for me via data pack.