### PR TITLE
Fix typos in lang/en_us for Squid Kebab & Frog Leg Kebab

### DIFF
--- a/src/main/resources/assets/crabbersdelight/lang/en_us.json
+++ b/src/main/resources/assets/crabbersdelight/lang/en_us.json
@@ -42,8 +42,8 @@
   "item.crabbersdelight.shrimp_fried_rice": "Shrimp Fried Rice",
   "item.crabbersdelight.jar_of_pickles": "Jar of Pickles",
   "item.crabbersdelight.sea_pickle_juice": "Sea Pickle Juice",
-  "item.crabbersdelight.squid_kebob": "Squid Kebab",
-  "item.crabbersdelight.frog_leg_kebob": "Frog Leg Kebab",
+  "item.crabbersdelight.squid_kebab": "Squid Kebab",
+  "item.crabbersdelight.frog_leg_kebab": "Frog Leg Kebab",
   "item.crabbersdelight.coral_crunch": "Coral Crunch",
 
   "item.crabbersdelight.soggy_flesh": "Soggy Flesh",


### PR DESCRIPTION
The language keys for those two items were incorrect. I tested this change using a resource pack and can confirm it works.